### PR TITLE
Fixed encoding NSNumber with boolean value.

### DIFF
--- a/CocoaAMF/AMFArchiver.m
+++ b/CocoaAMF/AMFArchiver.m
@@ -801,7 +801,7 @@ not allow externalizable objects (non-keyed archiving)!"];
 
 - (void)_encodeNumber:(NSNumber *)value
 {
-	if ([[value className] isEqualToString:@"NSCFBoolean"])
+	if ([[value className] isEqualToString:@"__NSCFBoolean"])
 	{
 		[self encodeUnsignedChar:kAMF0BooleanType];
 		[self encodeBool:[value boolValue]];


### PR DESCRIPTION
Compare [value className] with __NSCFBoolean not NSCFBoolean.
